### PR TITLE
Allow container.key and container[index] syntax in function calls

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CachedCalls"
 uuid = "f8c5305c-6a45-4f66-b1f2-5751ba853d4a"
 authors = ["Miha Zgubic <miha.zgubic@invenialabs.co.uk> and contributors"]
-version = "0.1.1"
+version = "0.1.2"
 
 [deps]
 FilePathsBase = "48062228-2e41-5def-b9a4-89aafe57970f"

--- a/src/CachedCalls.jl
+++ b/src/CachedCalls.jl
@@ -107,6 +107,9 @@ function _extract_kwargs(ex::Expr; keep_args=false)
         # need to `keep_args` because of `f(;c)` syntactic sugar does not result in :kw
         # expression but in a single arg :c to parameters
         return [(_extract_kwargs.(ex.args; keep_args=true)...)...]
+    # container.key or container[index] access
+    elseif Meta.isexpr(ex, [:., :ref])
+        return keep_args ? [(ex, ex)] : []
     else
         error("Unexpected input expression to _extract_kwargs: $ex")
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -88,9 +88,17 @@ using Test
 
         @testset "square bracket access" begin
             f(a; kw=0) = a + kw
+
             array = [1, 2, 3]
-            @test f(1, kw=2) == @cached_call f(array[1]; kw=array[2])
-            @test f(1, kw=2) == @cached_call f(array[1], kw=array[2])
+            call1 = @cached_call f(array[1]; kw=array[2])
+            call2 = @cached_call f(array[1], kw=array[2])
+            @test f(1, kw=2) == call1 == call2
+
+            array = [10, 20, 30]
+            call3 = @cached_call f(array[1]; kw=array[2])
+            call4 = @cached_call f(array[1], kw=array[2])
+            @test call1 != call3
+            @test call2 != call4
         end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -59,11 +59,9 @@ using Test
             call2 = @cached_call f(kw=1)
             kw = 1
             @static if VERSION >= v"1.5"
-                println("hi2")
                 call3 = @cached_call f(;kw)
                 @test f(;kw=1) == call1 == call2 == call3
             else
-                println("hi")
                 @test f(;kw=1) == call1 == call2
             end
         end
@@ -72,13 +70,27 @@ using Test
             f(a; kw=1) = a - kw
             a = 2.0
             kw = 1
-            call1 = @cached_call f(a; kw=1)
+            call1 = @cached_call f(a; kw=kw)
             @static if VERSION >= v"1.5"
                 call2 = @cached_call f(a; kw)
-                @test f(a; kw=1) == call1 == call2
+                @test f(a; kw=kw) == call1 == call2
             else
-                @test f(a; kw=1) == call1
+                @test f(a; kw=kw) == call1
             end
+        end
+
+        @testset "dot access" begin
+            f(a; kw=0) = a + kw
+            nt = (one=1, two=2)
+            @test f(1, kw=2) == @cached_call f(nt.one; kw=nt.two)
+            @test f(1, kw=2) == @cached_call f(nt.one, kw=nt.two)
+        end
+
+        @testset "square bracket access" begin
+            f(a; kw=0) = a + kw
+            array = [1, 2, 3]
+            @test f(1, kw=2) == @cached_call f(array[1]; kw=array[2])
+            @test f(1, kw=2) == @cached_call f(array[1], kw=array[2])
         end
     end
 end


### PR DESCRIPTION
previously
```
@cached_call f(container.key)
@cached_call f(container[index])
```
both errored, now they don't