### PR TITLE
add separate @hash_call macro

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CachedCalls"
 uuid = "f8c5305c-6a45-4f66-b1f2-5751ba853d4a"
 authors = ["Miha Zgubic <miha.zgubic@invenialabs.co.uk> and contributors"]
-version = "0.1.2"
+version = "0.1.3"
 
 [deps]
 FilePathsBase = "48062228-2e41-5def-b9a4-89aafe57970f"

--- a/src/CachedCalls.jl
+++ b/src/CachedCalls.jl
@@ -14,7 +14,7 @@ const CACHEDCALLS_PATH = Ref{PosixPath}()
 
 Caches the result of `f(args; kwargs)` to disk and returns the result. The next time
 `f(args; kwargs)` is called with the same values of `args` and `kwargs` the cached result
-is returned and `f` is not called again.
+is returned and `f` is not called again. Splatting it not yet supported.
 
 Restrictions on `f` apply: it must not mutate its arguments or access/mutate globals.
 These assumptions will not be checked and if violated could mean that an incorrect
@@ -38,6 +38,16 @@ macro cached_call(ex)
     end
 end
 
+"""
+    @hash_call f(args; kwargs)
+
+Computes the hash of the function call `f(args; kwargs)` by hashing `f`, the values of
+`args`, the names of `kwargs`, and the values of `kwargs`.
+
+Different order of kwargs will hash differently. Setting the default values of kwargs
+explicitly will hash differently than using the defaults implicitly. Splatting it not yet
+supported.
+"""
 macro hash_call(ex)
     func, args, kw_names, kw_values = _deconstruct(ex)
 

--- a/src/CachedCalls.jl
+++ b/src/CachedCalls.jl
@@ -42,7 +42,7 @@ macro hash_call(ex)
     func, args, kw_names, kw_values = _deconstruct(ex)
 
     return :(hash([
-        $(func), # function name
+        $(esc(func)), # function name
         $(esc.(args)...), # arg values
         $(kw_names)..., # kwarg names
         $(esc.(kw_values)...) # kwarg values
@@ -95,7 +95,6 @@ function _deconstruct(ex)
 
     # Extract arguments, kwarg names, and kwarg values.
     func, fargs = Iterators.peel(nonesc_ex.args)
-    length(nonesc_ex.args) == 1 && return string(func), [], [], []
 
     args = filter(subex -> !Meta.isexpr(subex, [:kw, :parameters]), collect(fargs))
     kwargs = _extract_kwargs(collect(fargs))
@@ -107,9 +106,10 @@ function _deconstruct(ex)
     if isesc
         args = esc.(args)
         kw_values = esc.(kw_values)
+        func = esc(func)
     end
 
-    return string(func), args, kw_names, kw_values
+    return func, args, kw_names, kw_values
 end
 
 """

--- a/src/CachedCalls.jl
+++ b/src/CachedCalls.jl
@@ -94,11 +94,7 @@ Deconstruct expression `ex` to a tuple (function name, arguments, kwarg names, k
 function _deconstruct(ex)
     # escaped expressions need their unescaped subexpression deconstructed
     isesc = Meta.isexpr(ex, :escape)
-    if isesc
-        nonesc_ex = ex.args[1]
-    else
-        nonesc_ex = ex
-    end
+    nonesc_ex = isesc ? ex.args[1] : ex
 
     # check assumptions about the call
     Meta.isexpr(nonesc_ex, :call) || error("Only :call expressions are supported, $ex was given.")

--- a/src/CachedCalls.jl
+++ b/src/CachedCalls.jl
@@ -39,7 +39,6 @@ macro cached_call(ex)
 end
 
 macro hash_call(ex)
-
     # escaped expressions need their unescaped subexpression deconstructed
     isesc = Meta.isexpr(ex, :escape)
     if isesc
@@ -62,14 +61,12 @@ macro hash_call(ex)
         kw_values = esc.(kw_values)
     end
 
-    return :(
-        hash([
-            $(func), # function name
-            $(esc.(args)...), # arg values
-            $(kw_names)..., # kwarg names
-            $(esc.(kw_values)...) # kwarg values
-        ])
-    )
+    return :(hash([
+        $(func), # function name
+        $(esc.(args)...), # arg values
+        $(kw_names)..., # kwarg names
+        $(esc.(kw_values)...) # kwarg values
+    ]))
 end
 
 """

--- a/src/CachedCalls.jl
+++ b/src/CachedCalls.jl
@@ -14,7 +14,7 @@ const CACHEDCALLS_PATH = Ref{PosixPath}()
 
 Caches the result of `f(args; kwargs)` to disk and returns the result. The next time
 `f(args; kwargs)` is called with the same values of `args` and `kwargs` the cached result
-is returned and `f` is not called again. Splatting it not yet supported.
+is returned and `f` is not called again. Splatting is not yet supported.
 
 Restrictions on `f` apply: it must not mutate its arguments or access/mutate globals.
 These assumptions will not be checked and if violated could mean that an incorrect
@@ -45,7 +45,7 @@ Computes the hash of the function call `f(args; kwargs)` by hashing `f`, the val
 `args`, the names of `kwargs`, and the values of `kwargs`.
 
 Different order of kwargs will hash differently. Setting the default values of kwargs
-explicitly will hash differently than using the defaults implicitly. Splatting it not yet
+explicitly will hash differently than using the defaults implicitly. Splatting is not yet
 supported.
 """
 macro hash_call(ex)

--- a/src/CachedCalls.jl
+++ b/src/CachedCalls.jl
@@ -79,7 +79,7 @@ end
 """
     _deconstruct(ex)
 
-Deconstruct expression `ex` to a tuple of function name, arguments, and keyword arguments.
+Deconstruct expression `ex` to a tuple (function name, arguments, kwarg names, kwarg values)
 """
 function _deconstruct(ex)
     # escaped expressions need their unescaped subexpression deconstructed
@@ -125,14 +125,17 @@ function _extract_kwargs(ex::Expr; keep_args=false)
     # kwargs specified without ;
     if Meta.isexpr(ex, :kw)
         return [(ex.args[1], ex.args[2]),]
+
     # kwargs specified with ;
     elseif Meta.isexpr(ex, :parameters)
         # need to `keep_args` because of `f(;c)` syntactic sugar does not result in :kw
         # expression but in a single arg :c to parameters
         return [(_extract_kwargs.(ex.args; keep_args=true)...)...]
+
     # container.key or container[index] access
     elseif Meta.isexpr(ex, [:., :ref])
         return keep_args ? [(ex, ex)] : []
+
     else
         error("Unexpected input expression to _extract_kwargs: $ex")
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,7 +6,7 @@ using Test
         @testset "f(1, 2, c)" begin
             ex = :(f(1, 2, c))
             func, args, kw_names, kw_values = CachedCalls._deconstruct(ex)
-            @test func == "f"
+            @test func == :f
             @test args == Any[1, 2, :c]
             @test kw_names == Any[]
             @test kw_values == Any[]
@@ -15,7 +15,7 @@ using Test
         @testset "f(;a=1, b=2, c)" begin
             ex = :(f(; a=1, b=2, c))
             func, args, kw_names, kw_values = CachedCalls._deconstruct(ex)
-            @test func == "f"
+            @test func == :f
             @test args == Any[]
             @test kw_names == [:a, :b, :c]
             @test kw_values == [1, 2, :c]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -41,16 +41,23 @@ using Test
         end
     end
 
-    @testset "@cached_call" begin
+    @testset "@cached_call and @hash_call" begin
         @testset "f()" begin
             f() = 2
-            @test f() == @cached_call(f()) == @cached_call f() # test first and second call
+            call1 = @cached_call f()
+            call2 = @cached_call f()
+            @test f() == call1 == call2
+
+            @test @hash_call(f()) isa UInt
         end
 
         @testset "f(a, b)" begin
             f(a, b) = a + b
-            @test f(1, 2) == @cached_call f(1, 2)
-            @test f(1, 2) != @cached_call f(2, 2)
+            a = 1
+            @test f(a, 2) == @cached_call f(a, 2)
+            @test f(a, 2) != @cached_call f(2, 2)
+
+            @test @hash_call(f(a, 2)) isa UInt
         end
 
         @testset "f(;kw=kw)" begin
@@ -58,9 +65,14 @@ using Test
             call1 = @cached_call f(;kw=1)
             call2 = @cached_call f(kw=1)
             kw = 1
+
+            @test @hash_call(f(;kw=1)) isa UInt
+            @test @hash_call(f(kw=1)) isa UInt
+
             @static if VERSION >= v"1.5"
                 call3 = @cached_call f(;kw)
                 @test f(;kw=1) == call1 == call2 == call3
+                @test @hash_call(f(;kw)) isa UInt
             else
                 @test f(;kw=1) == call1 == call2
             end
@@ -70,13 +82,8 @@ using Test
             f(a; kw=1) = a - kw
             a = 2.0
             kw = 1
-            call1 = @cached_call f(a; kw=kw)
-            @static if VERSION >= v"1.5"
-                call2 = @cached_call f(a; kw)
-                @test f(a; kw=kw) == call1 == call2
-            else
-                @test f(a; kw=kw) == call1
-            end
+            @test f(a; kw=kw) == @cached_call f(a; kw=kw)
+            @test @hash_call(f(a; kw=kw)) isa UInt
         end
 
         @testset "dot access" begin
@@ -84,6 +91,7 @@ using Test
             nt = (one=1, two=2)
             @test f(1, kw=2) == @cached_call f(nt.one; kw=nt.two)
             @test f(1, kw=2) == @cached_call f(nt.one, kw=nt.two)
+            @test @hash_call(f(nt.one; kw=nt.two)) isa UInt
         end
 
         @testset "square bracket access" begin
@@ -93,6 +101,7 @@ using Test
             call1 = @cached_call f(array[1]; kw=array[2])
             call2 = @cached_call f(array[1], kw=array[2])
             @test f(1, kw=2) == call1 == call2
+            @test @hash_call(f(array[1], kw=array[2])) isa UInt
 
             array = [10, 20, 30]
             call3 = @cached_call f(array[1]; kw=array[2])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,18 +5,20 @@ using Test
     @testset "_deconstruct" begin
         @testset "f(1, 2, c)" begin
             ex = :(f(1, 2, c))
-            func, args, kwargs = CachedCalls._deconstruct(ex)
+            func, args, kw_names, kw_values = CachedCalls._deconstruct(ex)
             @test func == "f"
             @test args == Any[1, 2, :c]
-            @test kwargs == Any[]
+            @test kw_names == Any[]
+            @test kw_values == Any[]
         end
 
         @testset "f(;a=1, b=2, c)" begin
             ex = :(f(; a=1, b=2, c))
-            func, args, kwargs = CachedCalls._deconstruct(ex)
+            func, args, kw_names, kw_values = CachedCalls._deconstruct(ex)
             @test func == "f"
             @test args == Any[]
-            @test kwargs == Tuple{Symbol,Any}[(:a, 1), (:b, 2), (:c, :c)]
+            @test kw_names == [:a, :b, :c]
+            @test kw_values == [1, 2, :c]
         end
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,7 +6,7 @@ using Test
         @testset "f(1, 2, c)" begin
             ex = :(f(1, 2, c))
             func, args, kwargs = CachedCalls._deconstruct(ex)
-            @test func == :f
+            @test func == "f"
             @test args == Any[1, 2, :c]
             @test kwargs == Any[]
         end
@@ -14,7 +14,7 @@ using Test
         @testset "f(;a=1, b=2, c)" begin
             ex = :(f(; a=1, b=2, c))
             func, args, kwargs = CachedCalls._deconstruct(ex)
-            @test func == :f
+            @test func == "f"
             @test args == Any[]
             @test kwargs == Tuple{Symbol,Any}[(:a, 1), (:b, 2), (:c, :c)]
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -80,7 +80,7 @@ using Test
             end
         end
 
-        @testset "f(;kw=kw)" begin
+        @testset "f(a ;kw=kw)" begin
             f(a; kw=1) = a - kw
             a = 2.0
             kw = 1


### PR DESCRIPTION
Closes #8 

Creates a separate macro `@hash_call` which only does the hashing. The existing `@cached_call` macro now uses the `@hash_call` macro internally, which requires `@hash_call` macro to work on expressions (when called directly) and on escaped expressions (when called from `@cached_call`).

Another notable change is that `_deconstruct` now returns the kwarg names and values separately, and deals with escaping internally.